### PR TITLE
v4.0.0 and Chores

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,42 +1,81 @@
 # Change Log
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 3.0.2 - 2019-02-08
-### Fixed
- - Fix package vulnerabilities that GitHub alerted us to
+## [Unreleased]
 
-## 3.0.1 - 2017-12-06
-### Fixed
- - Include TypeScript declaration file with package contents.
+- None
 
-## 3.0.0 - 2017-12-06
+## [4.0.0] - 2020-05-02
+
+### Changed
+
+- **BREAKING**: Constrain Knockout peer dependency versions to ^3.5.0
+- Remove @types/knockout dependency
+- Update TypeScript declarations to use new Knockout types
+
+## [3.0.2] - 2019-02-08
+
+### Fixed
+
+- Fix package vulnerabilities that GitHub alerted us to
+
+## [3.0.1] - 2017-12-06
+
+### Fixed
+
+- Include TypeScript declaration file with package contents.
+
+## [3.0.0] - 2017-12-06
+
 ### Added
- - TypeScript declaration file.
+
+- TypeScript declaration file.
 
 ### Changed
- - `connect` throws an error if `mapStateToParams` or `mergeParams` are not `null` or a function.
- - If `mapStateToParams` or `mergeParams` are `null`, the respective default will be used.
- - Calling the result of `connect()` without a function (view model) will throw an `Error` instead of a `TypeError`.
 
-## 2.0.0 - 2017-09-20
+- `connect` throws an error if `mapStateToParams` or `mergeParams` are not `null` or a function.
+- If `mapStateToParams` or `mergeParams` are `null`, the respective default will be used.
+- Calling the result of `connect()` without a function (view model) will throw an `Error` instead of a `TypeError`.
+
+## [2.0.0] - 2017-09-20
+
 ### Removed
- - CommonJS export (covered by UMD export)
+
+- CommonJS export (covered by UMD export)
 
 ### Changed
- - pkg.module now exports transpiled code
 
-## 1.0.2 - 2017-05-05
+- pkg.module now exports transpiled code
+
+## [1.0.2] - 2017-05-05
+
 ### Fixed
+
 - README.md links
 
-## 1.0.1 - 2017-05-05
+## [1.0.1] - 2017-05-05
+
 ### Changed
+
 - Update README.md with a link to the wiki
 
-## 1.0.0 - 2017-05-03
+## [1.0.0] - 2017-05-03
+
 ### Added
+
 - Initial files
 - API: `connect`, `getState`, and `setState`
+
+[unreleased]: https://github.com/Spreetail/knockout-store/compare/v4.0.0...HEAD
+[4.0.0]: https://github.com/Spreetail/knockout-store/compare/v3.0.2...v4.0.0
+[3.0.2]: https://github.com/Spreetail/knockout-store/compare/v3.0.1...v3.0.2
+[3.0.1]: https://github.com/Spreetail/knockout-store/compare/v3.0.0...v3.0.1
+[3.0.0]: https://github.com/Spreetail/knockout-store/compare/v2.0.0...v3.0.0
+[2.0.0]: https://github.com/Spreetail/knockout-store/compare/v1.0.2...v2.0.0
+[1.0.2]: https://github.com/Spreetail/knockout-store/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/Spreetail/knockout-store/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/Spreetail/knockout-store/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Pass the view model to be connected to the result of this function.
  If this argument is `null` or not specified, a function returning an empty object is used instead.
  - [`mergeParams(stateParams, ownParams): params`] (_Function_):
  If specified, this argument is a function responsible for merging `stateParams` (the result of `mapStateToParams`, see above) and `ownParams` (the `params` object the connected view model was called with).
- If this argument is `null` or not specified, `Object.assign({}, ownParams, statePrams)` is used instead.
+ If this argument is `null` or not specified, `Object.assign({}, ownParams, stateParams)` is used instead.
 
 ## Testing
 Run `npm run test` to start the [Karma](https://karma-runner.github.io/1.0/index.html)

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,34 @@
-import '@types/knockout';
+import { Observable, components } from 'knockout';
 
-export function setState(state: any): void;
+export function setState<T>(state: T): void;
 
-export function getState<T>(): KnockoutObservable<T>;
+export function getState<T>(): Observable<T>;
+
+interface ViewModelFactoryFunction {
+  (params?: components.ViewModelParams): components.ViewModel;
+}
+
+interface ViewModelInstantiator
+  extends components.ViewModelConstructor,
+    ViewModelFactoryFunction {}
+
+interface MapStateToParamsFn {
+  (
+    state?: any,
+    ownParams?: components.ViewModelParams
+  ): components.ViewModelParams;
+}
+
+interface MergeParamsFn {
+  (
+    stateParams: components.ViewModelParams,
+    ownParams: components.ViewModelParams
+  ): components.ViewModelParams;
+}
 
 export function connect(
-  mapStateToParams?: (state?: any, ownParams?: any) => any,
-  mergeParams?: (stateParams: any, ownParams: any) => any
+  mapStateToParams?: MapStateToParamsFn | null,
+  mergeParams?: MergeParamsFn | null
 ): (
-  viewModel: KnockoutComponentTypes.ViewModelFunction
-) => KnockoutComponentTypes.ViewModelFunction;
+  viewModel: components.ViewModelConstructor | ViewModelFactoryFunction
+) => ViewModelInstantiator;

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,8 +13,8 @@ interface ViewModelInstantiator
     ViewModelFactoryFunction {}
 
 interface MapStateToParamsFn {
-  (
-    state?: any,
+  <T>(
+    state?: T,
     ownParams?: components.ViewModelParams
   ): components.ViewModelParams;
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,3 +1,8 @@
+const puppeteer = require('puppeteer');
+
+// Use Chromium executable from puppeteer to test
+process.env.CHROME_BIN = puppeteer.executablePath();
+
 // Karma configuration
 // Generated on Tue May 02 2017 14:29:01 GMT-0500 (Central Daylight Time)
 
@@ -52,7 +57,7 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['PhantomJS'],
+    browsers: ['ChromeHeadless'],
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/knockout": {
-      "version": "3.4.67",
-      "resolved": "https://registry.npmjs.org/@types/knockout/-/knockout-3.4.67.tgz",
-      "integrity": "sha512-VYg5VcZecApmAILpSsTtD0UUAHUIGWi7/um9WQjbk/ajPWinGZAKkH9U8zbFmvdxfafFGvcRm655XRm6vc6hoQ=="
-    },
     "@types/mime-types": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.0.tgz",
@@ -4806,6 +4801,12 @@
       "version": "0.2.0",
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
       "dev": true
     },
     "private": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,32 @@
   "requires": true,
   "dependencies": {
     "@types/knockout": {
-      "version": "3.4.63",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/@types/knockout/-/knockout-3.4.63.tgz",
-      "integrity": "sha1-XDGs7Jfq6hQ7GW3cJFxF3ZEe5WU="
+      "version": "3.4.67",
+      "resolved": "https://registry.npmjs.org/@types/knockout/-/knockout-3.4.67.tgz",
+      "integrity": "sha512-VYg5VcZecApmAILpSsTtD0UUAHUIGWi7/um9WQjbk/ajPWinGZAKkH9U8zbFmvdxfafFGvcRm655XRm6vc6hoQ=="
+    },
+    "@types/mime-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.0.tgz",
+      "integrity": "sha1-nKUs2jY/aZxpRmwqbM2q2RPqenM=",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "13.13.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.4.tgz",
+      "integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA==",
+      "dev": true,
+      "optional": true
+    },
+    "@types/yauzl": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
+      "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "accepts": {
       "version": "1.3.5",
@@ -20,9 +43,9 @@
       }
     },
     "acorn": {
-      "version": "5.7.3",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha1-Z6ojG/iBKXS4UjWpZ3Hra9B+onk=",
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
       "dev": true
     },
     "acorn-jsx": {
@@ -46,6 +69,12 @@
       "version": "0.8.2",
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/after/-/after-0.8.2.tgz",
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
+      "dev": true
+    },
+    "agent-base": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
+      "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
       "dev": true
     },
     "ajv": {
@@ -342,9 +371,9 @@
           "dev": true
         },
         "kind-of": {
-          "version": "6.0.2",
-          "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
           "dev": true
         },
         "micromatch": {
@@ -372,8 +401,8 @@
     },
     "argparse": {
       "version": "1.0.10",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
@@ -428,21 +457,6 @@
       "integrity": "sha1-O7xCdd1YTMGxCAm4nU6LY6aednU=",
       "dev": true
     },
-    "asn1": {
-      "version": "0.2.4",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
-      "dev": true,
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
-    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -467,28 +481,10 @@
       "integrity": "sha1-ePrtjD0HSrgfIrTphdeehzj3IPg=",
       "dev": true
     },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
-    },
     "atob": {
       "version": "2.1.2",
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/atob/-/atob-2.1.2.tgz",
       "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
-      "dev": true
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
-    },
-    "aws4": {
-      "version": "1.8.0",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8=",
       "dev": true
     },
     "babel-code-frame": {
@@ -1125,8 +1121,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -1137,20 +1133,17 @@
       "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
       "dev": true
     },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+      "dev": true
+    },
     "base64id": {
       "version": "1.0.0",
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/base64id/-/base64id-1.0.0.tgz",
       "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
       "dev": true
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "dev": true,
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "better-assert": {
       "version": "1.0.2",
@@ -1166,6 +1159,36 @@
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/binary-extensions/-/binary-extensions-1.13.0.tgz",
       "integrity": "sha1-lSPgATBqMkRLkHQj8d4hZCIvarE=",
       "dev": true
+    },
+    "bl": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
+      "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "blob": {
       "version": "0.0.5",
@@ -1235,6 +1258,16 @@
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
     },
+    "buffer": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      }
+    },
     "buffer-alloc": {
       "version": "1.2.0",
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
@@ -1249,6 +1282,12 @@
       "version": "1.1.0",
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
       "integrity": "sha1-vX3CauKXLQ7aJTvgYdupkjScGfA=",
+      "dev": true
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
     },
     "buffer-fill": {
@@ -1319,12 +1358,6 @@
       "version": "0.2.0",
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
-      "dev": true
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
     "chai": {
@@ -1490,6 +1523,12 @@
         }
       }
     },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true
+    },
     "circular-json": {
       "version": "0.3.3",
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/circular-json/-/circular-json-0.3.3.tgz",
@@ -1584,15 +1623,6 @@
       "dev": true,
       "requires": {
         "lodash": "^4.5.0"
-      }
-    },
-    "combined-stream": {
-      "version": "1.0.7",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/combined-stream/-/combined-stream-1.0.7.tgz",
-      "integrity": "sha1-LR0kMXr7ir6V1tLAsHtXgTU52Cg=",
-      "dev": true,
-      "requires": {
-        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -1705,15 +1735,6 @@
       "integrity": "sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=",
       "dev": true
     },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "date-format": {
       "version": "1.2.0",
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/date-format/-/date-format-1.2.0.tgz",
@@ -1805,18 +1826,12 @@
           "dev": true
         },
         "kind-of": {
-          "version": "6.0.2",
-          "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
           "dev": true
         }
       }
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
     },
     "depd": {
       "version": "1.1.2",
@@ -1866,16 +1881,6 @@
         "void-elements": "^2.0.0"
       }
     },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "dev": true,
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/ee-first/-/ee-first-1.1.1.tgz",
@@ -1887,6 +1892,15 @@
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "engine.io": {
       "version": "3.2.1",
@@ -1986,12 +2000,6 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
-    },
-    "es6-promise": {
-      "version": "4.2.5",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/es6-promise/-/es6-promise-4.2.5.tgz",
-      "integrity": "sha1-2m0NVpLvtGHggsFIF/4kJ9j10FQ=",
-      "dev": true
     },
     "escape-html": {
       "version": "1.0.3",
@@ -2170,8 +2178,8 @@
     },
     "esprima": {
       "version": "4.0.1",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "esquery": {
@@ -2325,24 +2333,6 @@
         "is-extglob": "^1.0.0"
       }
     },
-    "extract-zip": {
-      "version": "1.6.7",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/extract-zip/-/extract-zip-1.6.7.tgz",
-      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
-      "dev": true,
-      "requires": {
-        "concat-stream": "1.6.2",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.1",
-        "yauzl": "2.4.1"
-      }
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
-    },
     "fast-deep-equal": {
       "version": "1.1.0",
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
@@ -2360,15 +2350,6 @@
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
-    },
-    "fd-slicer": {
-      "version": "1.0.1",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/fd-slicer/-/fd-slicer-1.0.1.tgz",
-      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-      "dev": true,
-      "requires": {
-        "pend": "~1.2.0"
-      }
     },
     "figures": {
       "version": "2.0.0",
@@ -2484,23 +2465,6 @@
         "for-in": "^1.0.1"
       }
     },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
-    },
-    "form-data": {
-      "version": "2.3.3",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
-      "dev": true,
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      }
-    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -2519,16 +2483,11 @@
         "null-check": "^1.0.0"
       }
     },
-    "fs-extra": {
+    "fs-constants": {
       "version": "1.0.0",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/fs-extra/-/fs-extra-1.0.0.tgz",
-      "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^2.1.0",
-        "klaw": "^1.0.0"
-      }
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -2556,7 +2515,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2599,7 +2559,8 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
@@ -2610,7 +2571,8 @@
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2727,7 +2689,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2739,6 +2702,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2761,12 +2725,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2785,6 +2751,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2878,6 +2845,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2963,7 +2931,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2999,6 +2968,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3018,6 +2988,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3061,12 +3032,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3088,20 +3061,20 @@
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
+    "get-stream": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+      "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+      "dev": true,
+      "requires": {
+        "pump": "^3.0.0"
+      }
+    },
     "get-value": {
       "version": "2.0.6",
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
     },
     "glob": {
       "version": "7.1.3",
@@ -3153,48 +3126,6 @@
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/growl/-/growl-1.10.3.tgz",
       "integrity": "sha1-GSa6kM8+3+KttJJ/WIC8IsZseQ8=",
       "dev": true
-    },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
-    },
-    "har-validator": {
-      "version": "5.1.3",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
-      "dev": true,
-      "requires": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.8.1",
-          "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/ajv/-/ajv-6.8.1.tgz",
-          "integrity": "sha1-CJC5N0KYXr+Jc802XFsjkgzjyyA=",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "2.0.1",
-          "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-          "dev": true
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
-          "dev": true
-        }
-      }
     },
     "has": {
       "version": "1.0.3",
@@ -3309,16 +3240,6 @@
         }
       }
     },
-    "hasha": {
-      "version": "2.2.0",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/hasha/-/hasha-2.2.0.tgz",
-      "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
-      "dev": true,
-      "requires": {
-        "is-stream": "^1.0.1",
-        "pinkie-promise": "^2.0.0"
-      }
-    },
     "he": {
       "version": "1.1.1",
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/he/-/he-1.1.1.tgz",
@@ -3358,15 +3279,31 @@
         "requires-port": "^1.0.0"
       }
     },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+    "https-proxy-agent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+      "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "agent-base": "5",
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
       }
     },
     "iconv-lite": {
@@ -3377,6 +3314,12 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "dev": true
     },
     "ignore": {
       "version": "3.3.10",
@@ -3669,12 +3612,6 @@
       "integrity": "sha1-+xj4fOH+uSUWnJpAfBkxijIG7Yg=",
       "dev": true
     },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
-    },
     "is-symbol": {
       "version": "1.0.2",
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/is-symbol/-/is-symbol-1.0.2.tgz",
@@ -3683,12 +3620,6 @@
       "requires": {
         "has-symbols": "^1.0.0"
       }
-    },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
     },
     "is-windows": {
       "version": "1.0.2",
@@ -3726,12 +3657,6 @@
         "isarray": "1.0.0"
       }
     },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
-    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -3739,31 +3664,19 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.1",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/js-yaml/-/js-yaml-3.12.1.tgz",
-      "integrity": "sha1-KVyGMqGKI+BUz1ydPOyv5ngWdgA=",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
     },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
-    },
     "jsesc": {
       "version": "1.3.0",
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/jsesc/-/jsesc-1.3.0.tgz",
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-      "dev": true
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
     "json-schema-traverse": {
@@ -3778,38 +3691,11 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
-    },
     "json5": {
       "version": "0.5.1",
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
-    },
-    "jsonfile": {
-      "version": "2.4.0",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
     },
     "jsx-ast-utils": {
       "version": "2.0.1",
@@ -3895,16 +3781,6 @@
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
-      }
-    },
-    "karma-phantomjs-launcher": {
-      "version": "1.0.4",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/karma-phantomjs-launcher/-/karma-phantomjs-launcher-1.0.4.tgz",
-      "integrity": "sha1-0jyjSAG9qYY60xjju0vUBisTrNI=",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.0.1",
-        "phantomjs-prebuilt": "^2.1.7"
       }
     },
     "karma-rollup-preprocessor": {
@@ -4243,8 +4119,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         },
         "micromatch": {
@@ -4276,12 +4152,6 @@
         }
       }
     },
-    "kew": {
-      "version": "0.7.0",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/kew/-/kew-0.7.0.tgz",
-      "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
-      "dev": true
-    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/kind-of/-/kind-of-3.2.2.tgz",
@@ -4291,19 +4161,10 @@
         "is-buffer": "^1.1.5"
       }
     },
-    "klaw": {
-      "version": "1.3.1",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/klaw/-/klaw-1.3.1.tgz",
-      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.9"
-      }
-    },
     "knockout": {
-      "version": "3.4.2",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/knockout/-/knockout-3.4.2.tgz",
-      "integrity": "sha1-6HlY3netHpNvfOZFuri118RW2Tc=",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/knockout/-/knockout-3.5.1.tgz",
+      "integrity": "sha512-wRJ9I4az0QcsH7A4v4l0enUpkS++MBx0BnL/68KaLzJg7x1qmbjSlwEoCNol7KTYZ+pmtI7Eh2J0Nu6/2Z5J/Q==",
       "dev": true
     },
     "levn": {
@@ -4317,9 +4178,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40=",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "log4js": {
@@ -4477,9 +4338,9 @@
       "dev": true
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha1-pJ5yaNzhoNlpjkUybFYm3zVD0P4=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -4488,8 +4349,8 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4"
@@ -4498,13 +4359,27 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        }
       }
+    },
+    "mkdirp-classic": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.2.tgz",
+      "integrity": "sha512-ejdnDQcR75gwknmMw/tx02AuRs8jCtqFoFqDZMjiNxsu85sRIJVXDKHuLYvUUPRBUtV2FpSZa9bL1BUa3BdR2g==",
+      "dev": true
     },
     "mocha": {
       "version": "4.1.0",
@@ -4552,6 +4427,15 @@
           "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/has-flag/-/has-flag-2.0.0.tgz",
           "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
         },
         "supports-color": {
           "version": "4.4.0",
@@ -4615,9 +4499,9 @@
           "dev": true
         },
         "kind-of": {
-          "version": "6.0.2",
-          "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
           "dev": true
         }
       }
@@ -4653,12 +4537,6 @@
       "version": "1.0.1",
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
-    },
-    "oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU=",
       "dev": true
     },
     "object-assign": {
@@ -4906,52 +4784,6 @@
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
     },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
-    },
-    "phantomjs-prebuilt": {
-      "version": "2.1.16",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
-      "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
-      "dev": true,
-      "requires": {
-        "es6-promise": "^4.0.3",
-        "extract-zip": "^1.6.5",
-        "fs-extra": "^1.0.0",
-        "hasha": "^2.2.0",
-        "kew": "^0.7.0",
-        "progress": "^1.1.8",
-        "request": "^2.81.0",
-        "request-progress": "^2.0.1",
-        "which": "^1.2.10"
-      },
-      "dependencies": {
-        "progress": {
-          "version": "1.1.8",
-          "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/progress/-/progress-1.1.8.tgz",
-          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
-          "dev": true
-        }
-      }
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
-      "requires": {
-        "pinkie": "^2.0.0"
-      }
-    },
     "pluralize": {
       "version": "7.0.0",
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/pluralize/-/pluralize-7.0.0.tgz",
@@ -5004,23 +4836,125 @@
         "object-assign": "^4.1.1"
       }
     },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
-    "psl": {
-      "version": "1.1.31",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/psl/-/psl-1.1.31.tgz",
-      "integrity": "sha1-6aqG0BAbWxBcvpOsa3hM1UcnYYQ=",
-      "dev": true
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
-    "punycode": {
-      "version": "2.1.1",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
-      "dev": true
+    "puppeteer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-3.0.2.tgz",
+      "integrity": "sha512-5jS/POFVDW9fqb76O8o0IBpXOnq+Na8ocGMggYtnjCRBRqmAFvX0csmwgLOHkYnQ/vCBcBPYlOq0Pp60z1850Q==",
+      "dev": true,
+      "requires": {
+        "@types/mime-types": "^2.1.0",
+        "debug": "^4.1.0",
+        "extract-zip": "^2.0.0",
+        "https-proxy-agent": "^4.0.0",
+        "mime": "^2.0.3",
+        "mime-types": "^2.1.25",
+        "progress": "^2.0.1",
+        "proxy-from-env": "^1.0.0",
+        "rimraf": "^3.0.2",
+        "tar-fs": "^2.0.0",
+        "unbzip2-stream": "^1.3.3",
+        "ws": "^7.2.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "extract-zip": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.0.tgz",
+          "integrity": "sha512-i42GQ498yibjdvIhivUsRslx608whtGoFIhF26Z7O4MYncBxp8CwalOs1lnHy21A9sIohWO2+uiE4SRtC9JXDg==",
+          "dev": true,
+          "requires": {
+            "@types/yauzl": "^2.9.1",
+            "debug": "^4.1.1",
+            "get-stream": "^5.1.0",
+            "yauzl": "^2.10.0"
+          }
+        },
+        "fd-slicer": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+          "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+          "dev": true,
+          "requires": {
+            "pend": "~1.2.0"
+          }
+        },
+        "mime-db": {
+          "version": "1.44.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+          "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.27",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+          "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+          "dev": true,
+          "requires": {
+            "mime-db": "1.44.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "ws": {
+          "version": "7.2.5",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.5.tgz",
+          "integrity": "sha512-C34cIU4+DB2vMyAbmEKossWq2ZQDr6QEyuuCzWrM9zfw1sGc0mYiJ0UnG9zzNykt49C2Fi34hvr2vssFQRS6EA==",
+          "dev": true
+        },
+        "yauzl": {
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+          "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+          "dev": true,
+          "requires": {
+            "buffer-crc32": "~0.2.3",
+            "fd-slicer": "~1.1.0"
+          }
+        }
+      }
     },
     "qjobs": {
       "version": "1.2.0",
@@ -5052,9 +4986,9 @@
           "dev": true
         },
         "kind-of": {
-          "version": "6.0.2",
-          "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
           "dev": true
         }
       }
@@ -5362,9 +5296,9 @@
           "dev": true
         },
         "kind-of": {
-          "version": "6.0.2",
-          "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
           "dev": true
         },
         "micromatch": {
@@ -5497,43 +5431,6 @@
       "dev": true,
       "requires": {
         "is-finite": "^1.0.0"
-      }
-    },
-    "request": {
-      "version": "2.88.0",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/request/-/request-2.88.0.tgz",
-      "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
-      "dev": true,
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      }
-    },
-    "request-progress": {
-      "version": "2.0.1",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/request-progress/-/request-progress-2.0.1.tgz",
-      "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
-      "dev": true,
-      "requires": {
-        "throttleit": "^1.0.0"
       }
     },
     "require-relative": {
@@ -5738,9 +5635,9 @@
       "dev": true
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -5895,8 +5792,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -6050,23 +5947,6 @@
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
-    },
-    "sshpk": {
-      "version": "1.16.1",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
-      "dev": true,
-      "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      }
     },
     "static-extend": {
       "version": "0.1.2",
@@ -6226,16 +6106,48 @@
         }
       }
     },
+    "tar-fs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.1.tgz",
+      "integrity": "sha512-6tzWDMeroL87uF/+lin46k+Q+46rAJ0SyPGz7OW7wTgblI273hsBqk2C1j0/xNadNLKDTUL9BukSjB7cwgmlPA==",
+      "dev": true,
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.0.0"
+      }
+    },
+    "tar-stream": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.2.tgz",
+      "integrity": "sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.0.1",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
-    },
-    "throttleit": {
-      "version": "1.0.0",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/throttleit/-/throttleit-1.0.0.tgz",
-      "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
       "dev": true
     },
     "through": {
@@ -6307,43 +6219,10 @@
         }
       }
     },
-    "tough-cookie": {
-      "version": "2.4.3",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
-      "dev": true,
-      "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
-        }
-      }
-    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
     "type-check": {
@@ -6407,39 +6286,26 @@
       "integrity": "sha1-n+FTahCmZKZSZqHjzPhf02MCvJw=",
       "dev": true
     },
+    "unbzip2-stream": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.2.tgz",
+      "integrity": "sha512-pZMVAofMrrHX6Ik39hCk470kulCbmZ2SWfQLPmTWqfJV/oUm0gn1CblvHdUu4+54Je6Jq34x8kY6XjTy6dMkOg==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
+      }
+    },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "unpipe": {
@@ -6500,15 +6366,6 @@
       "integrity": "sha1-NSVll+RqWB20eT0M5H+prr/J+r0=",
       "dev": true
     },
-    "uri-js": {
-      "version": "4.2.2",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
-      "dev": true,
-      "requires": {
-        "punycode": "^2.1.0"
-      }
-    },
     "urix": {
       "version": "0.1.0",
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/urix/-/urix-0.1.0.tgz",
@@ -6542,23 +6399,6 @@
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
-    },
-    "uuid": {
-      "version": "3.3.2",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE=",
-      "dev": true
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
     },
     "vlq": {
       "version": "0.2.3",
@@ -6624,15 +6464,6 @@
       "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
-    },
-    "yauzl": {
-      "version": "2.4.1",
-      "resolved": "http://packagebot.tools.spreetail.org/npm/spreepm/yauzl/-/yauzl-2.4.1.tgz",
-      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
-      "dev": true,
-      "requires": {
-        "fd-slicer": "~1.0.1"
-      }
     },
     "yeast": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "clean": "rimraf dist",
     "build-fresh": "npm run clean && npm run build",
     "preversion": "npm run lint && npm run test-once",
-    "prepublishOnly": "npm run build-fresh"
+    "prepublishOnly": "npm run build-fresh",
+    "prettier": "prettier --write \"{{src,tests,rollup}/**/*.js,index.d.ts}\""
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
   "main": "dist/knockout-store.js",
   "module": "dist/knockout-store.es.js",
   "types": "index.d.ts",
-  "dependencies": {
-    "@types/knockout": "^3.4.67"
-  },
+  "dependencies": {},
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-plugin-transform-object-assign": "^6.22.0",
@@ -31,7 +29,7 @@
     "rollup-plugin-uglify": "^2.0.1"
   },
   "peerDependencies": {
-    "knockout": "*"
+    "knockout": "^3.5.0"
   },
   "scripts": {
     "test": "karma start",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "module": "dist/knockout-store.es.js",
   "types": "index.d.ts",
   "dependencies": {
-    "@types/knockout": "^3.4.47"
+    "@types/knockout": "^3.4.67"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",
@@ -19,11 +19,10 @@
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-mocha": "^1.3.0",
-    "karma-phantomjs-launcher": "^1.0.4",
     "karma-rollup-preprocessor": "^5.0.2",
-    "knockout": "^3.4.2",
+    "knockout": "^3.5.1",
     "mocha": "^4.0.1",
-    "phantomjs-prebuilt": "^2.1.16",
+    "puppeteer": "^3.0.2",
     "rimraf": "^2.6.2",
     "rollup": "^0.52.1",
     "rollup-plugin-babel": "^3.0.2",
@@ -46,7 +45,7 @@
     "clean": "rimraf dist",
     "build-fresh": "npm run clean && npm run build",
     "preversion": "npm run lint && npm run test-once",
-    "prepublish": "npm run build-fresh"
+    "prepublishOnly": "npm run build-fresh"
   },
   "repository": {
     "type": "git",
@@ -62,7 +61,7 @@
     "store",
     "connect"
   ],
-  "author": "Alex Bainter <alex.bainter@spreetail.com> (https://github.com/metalex9)",
+  "author": "Alex Bainter <alex@alexbainter.com> (https://alexbainter.com)",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/Spreetail/knockout-store/issues"

--- a/src/connect.js
+++ b/src/connect.js
@@ -11,9 +11,7 @@ const throwIfNotAFunction = (o, message) => {
 };
 
 const makeNullableFunctionArgInvalidTypeMessage = (arg, argName) =>
-  `Invalid type '${typeof arg}' for connect parameter ${argName}. ${
-    argName
-  } must be a null or a function.`;
+  `Invalid type '${typeof arg}' for connect parameter ${argName}. ${argName} must be a null or a function.`;
 
 const throwIfNullableFuctionArgNotAFunction = (arg, argName) => {
   throwIfNotAFunction(
@@ -37,12 +35,12 @@ const connect = (
   );
   throwIfNullableFuctionArgNotAFunction(mergeParamsFunc, 'mergeParams');
 
-  return ViewModel => {
+  return (ViewModel) => {
     throwIfNotAFunction(
       ViewModel,
       `Invalid type '${typeof ViewModel}' for ViewModel passed to result of connect(). ViewModel must be a function.`
     );
-    return ownParams => {
+    return (ownParams) => {
       const state = getState();
       const stateParams = mapStateToParamsFunc(state(), ownParams);
       const mergedParams = mergeParamsFunc(stateParams, ownParams);

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,4 @@
 import connect from './connect';
 import { setState, getState } from './store';
 
-export {
-    setState,
-    getState,
-    connect,
-};
+export { setState, getState, connect };

--- a/src/store.js
+++ b/src/store.js
@@ -3,11 +3,11 @@ import ko from 'knockout';
 const stateObservable = ko.observable();
 
 function setState(state) {
-    stateObservable(state);
+  stateObservable(state);
 }
 
 function getState() {
-    return stateObservable;
+  return stateObservable;
 }
 
 export { setState, getState };

--- a/tests/connect.spec.js
+++ b/tests/connect.spec.js
@@ -34,7 +34,7 @@ describe('connect', () => {
     expect(() => connect()(null, 'not null or a function')).to.throw(Error);
   });
   it('should use the default mapStateToParams if given null', () => {
-    const mergeParams = stateParams => {
+    const mergeParams = (stateParams) => {
       expect(stateParams).to.eql({});
       mergeParams.called = true;
     };
@@ -125,9 +125,10 @@ describe('connect', () => {
         expect(ownParams).to.equal(params);
         mergeParamsCalled = true;
       }
-      const ConnectedViewModel = connect(mapStateToParams, mergeParams)(
-        viewModelMock
-      );
+      const ConnectedViewModel = connect(
+        mapStateToParams,
+        mergeParams
+      )(viewModelMock);
       new ConnectedViewModel(params); // eslint-disable-line no-new
       expect(mergeParamsCalled).to.be.true;
     });
@@ -141,9 +142,10 @@ describe('connect', () => {
       function mergeParams(stateParams, ownParams) {
         return ownParams;
       }
-      const ConnectedViewModel = connect(mapStateToParams, mergeParams)(
-        viewModelMock
-      );
+      const ConnectedViewModel = connect(
+        mapStateToParams,
+        mergeParams
+      )(viewModelMock);
       const { params } = new ConnectedViewModel(testParams);
       expect(params).to.equal(testParams);
     });

--- a/tests/store.spec.js
+++ b/tests/store.spec.js
@@ -2,29 +2,29 @@ import ko from 'knockout';
 import { getState, setState } from '../src/store';
 
 describe('store', () => {
-    afterEach(() => {
-        setState(undefined); // eslint-disable-line no-undefined
+  afterEach(() => {
+    setState(undefined); // eslint-disable-line no-undefined
+  });
+  describe('getState', () => {
+    it('should return an observable', () => {
+      const state = getState();
+      expect(ko.isObservable(state)).to.be.true;
     });
-    describe('getState', () => {
-        it('should return an observable', () => {
-            const state = getState();
-            expect(ko.isObservable(state)).to.be.true;
-        });
-        it('should return an observable with an undefined value', () => {
-            const state = getState();
-            expect(state()).to.be.undefined;
-        });
+    it('should return an observable with an undefined value', () => {
+      const state = getState();
+      expect(state()).to.be.undefined;
     });
-    it('should update state', () => {
-        const initialState = {
-            prop1: 1,
-            prop2: {
-                prop3: 2
-            }
-        };
-        setState(initialState);
-        const state = getState();
-        // checks for '==='' equivalence
-        expect(state()).to.equal(initialState);
-    });
+  });
+  it('should update state', () => {
+    const initialState = {
+      prop1: 1,
+      prop2: {
+        prop3: 2,
+      },
+    };
+    setState(initialState);
+    const state = getState();
+    // checks for '==='' equivalence
+    expect(state()).to.equal(initialState);
+  });
 });


### PR DESCRIPTION
## Library Changes
- **BREAKING**: Constrain Knockout peer dependency versions to ^3.5.0
- Remove @types/knockout dependency
- Update TypeScript declarations to use new Knockout types

## Repo Changes
- Fix typo in README.md
- Update CHANGELOG.md to actually follow the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format
- Migrate test runner from PhantomJS to Headless Chromium because it's now 2020
- Adds [Prettier](https://prettier.io/) script and reformats source files with it

Resolves #10.

After merging I'll update the version to 4.0.0 and publish to npm